### PR TITLE
Fixing bug in ternary operator to allow username w/ blank password

### DIFF
--- a/qpython/qconnection.py
+++ b/qpython/qconnection.py
@@ -156,7 +156,7 @@ class QConnection(object):
 
     def _initialize(self):
         '''Performs a IPC protocol handshake.'''
-        credentials = self.username + ':' + self.password if self.password else ''
+        credentials = self.username + ':' + (self.password if self.password else '')
         self._connection.send(credentials + '\3\0')
         response = self._connection.recv(1)
 

--- a/qpython/qconnection.py
+++ b/qpython/qconnection.py
@@ -156,7 +156,7 @@ class QConnection(object):
 
     def _initialize(self):
         '''Performs a IPC protocol handshake.'''
-        credentials = self.username + ':' + (self.password if self.password else '')
+        credentials = (self.username if self.username else '') + ':' + (self.password if self.password else '')
         self._connection.send(credentials + '\3\0')
         response = self._connection.recv(1)
 


### PR DESCRIPTION
Perhaps not a common scenario but one we see at my workplace. Existing code will always result in `credentials = ''` if password is blank or not supplied.