### PR TITLE
Serialization of Lists of Strings

### DIFF
--- a/qpython/qreader.py
+++ b/qpython/qreader.py
@@ -252,7 +252,7 @@ class QReader(object):
     def _read_string(self, qtype = QSTRING, options = READER_CONFIGURATION):
         self._buffer.skip()  # ignore attributes
         length = self._buffer.get_int()
-        return self._buffer.raw(length) if length > 0 else b''
+        return self._buffer.raw(length).decode('latin-1') if length > 0 else ''
 
 
     @parse(QSYMBOL)

--- a/qpython/qwriter.py
+++ b/qpython/qwriter.py
@@ -152,8 +152,16 @@ class QWriter(object):
             self._write(element)
 
 
-    @serialize(str, bytes)
+    @serialize(str)
     def _write_string(self, data):
+        self._buffer.write(struct.pack('=bxi', QSTRING, len(data)))
+        if isinstance(data, str):
+            self._buffer.write(data.encode("latin-1"))
+        else:
+            self._buffer.write(data)
+
+    @serialize(bytes)
+    def _write_bytes(self, data):
         if len(data) == 1:
             self._write_atom(ord(data), QCHAR)
         else:


### PR DESCRIPTION
I found the existing behavior when serializing length one strings to be surprising.

    s = Series(["One","Two","3"])
    s.meta = MetaData(qtype=QSTRING_LIST)

    k.sync('type each',s)
        0    10
        1    10
        2   -10
        dtype: int1

    k.sync('{x like "Two"}', s)
        `type

I realize that QSTRING_LIST == QGENERIC_LIST but as far as I can tell there is no way to serialize a list of strings without the risk of some ending up as characters.

This fork contains a pretty straightforward change - QWriter will now always serialize str as a QSTRING regardless of its length.

The bytes type retains old behaviour so a bytestring will serialize as a QSTRING while a length-one bytes will serialize to the QCHAR type.  This change is carried over to QReader, so QSTRING is converted to str and QCHAR is converted to bytes.

I'm not sure if this is the best approach to the problem, or if other people even consider it an issue but I figured I'd toss it out as an option.