### PR TITLE
New feature: Connection setup timeout similar to hopen (`:host:port;<timeout>)

### DIFF
--- a/qpython/qconnection.py
+++ b/qpython/qconnection.py
@@ -62,6 +62,7 @@ class QConnection(object):
      - `username` (`string` or `None`) - username for q authentication/authorization
      - `password` (`string` or `None`) - password for q authentication/authorization
      - `timeout` (`nonnegative float` or `None`) - set a timeout on blocking socket operations
+     - `connectionTimeout` (`nonnegative float` or `None`) - set a timeout for the initial connection setup (similar to hopen (`host:port;<timeout)
      - `encoding` (`string`) - string encoding for data deserialization
      - `reader_class` (subclass of `QReader`) - data deserializer
      - `writer_class` (subclass of `QWriter`) - data serializer
@@ -78,7 +79,7 @@ class QConnection(object):
     '''
 
 
-    def __init__(self, host, port, username = None, password = None, timeout = None, encoding = 'latin-1', reader_class = None, writer_class = None, **options):
+    def __init__(self, host, port, username = None, password = None, timeout = None, connectionTimeout = None, encoding = 'latin-1', reader_class = None, writer_class = None, **options):
         self.host = host
         self.port = port
         self.username = username
@@ -89,6 +90,7 @@ class QConnection(object):
         self._protocol_version = None
 
         self.timeout = timeout
+        self.connectionTimeout = connectionTimeout
 
         self._encoding = encoding
 
@@ -142,6 +144,7 @@ class QConnection(object):
 
             self._init_socket()
             self._initialize()
+            self._connection.settimeout(self.timeout)
 
             self._writer = self._writer_class(self._connection, protocol_version = self._protocol_version, encoding = self._encoding)
             self._reader = self._reader_class(self._connection_file, encoding = self._encoding)
@@ -150,9 +153,8 @@ class QConnection(object):
     def _init_socket(self):
         '''Initialises the socket used for communicating with a q service,'''
         try:
-            self._connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._connection = socket.create_connection((self.host, self.port), self.connectionTimeout)
             self._connection.connect((self.host, self.port))
-            self._connection.settimeout(self.timeout)
             self._connection_file = self._connection.makefile('b')
         except:
             self._connection = None
@@ -184,6 +186,7 @@ class QConnection(object):
 
     def _initialize(self):
         '''Performs a IPC protocol handshake.'''
+        self._connection.settimeout(self.connectionTimeout)
         credentials = (self.username if self.username else '') + ':' + (self.password if self.password else '')
         credentials = credentials.encode(self._encoding)
         self._connection.send(credentials + b'\3\0')
@@ -192,6 +195,7 @@ class QConnection(object):
         if len(response) != 1:
             self.close()
             self._init_socket()
+            self._connection.settimeout(self.connectionTimeout)
 
             self._connection.send(credentials + b'\0')
             response = self._connection.recv(1)

--- a/qpython/qconnection.py
+++ b/qpython/qconnection.py
@@ -62,7 +62,7 @@ class QConnection(object):
      - `username` (`string` or `None`) - username for q authentication/authorization
      - `password` (`string` or `None`) - password for q authentication/authorization
      - `timeout` (`nonnegative float` or `None`) - set a timeout on blocking socket operations
-     - `connectionTimeout` (`nonnegative float` or `None`) - set a timeout for the initial connection setup (similar to hopen (`host:port;<timeout)
+     - `connectionTimeout` (`nonnegative float` or `None`) - set a timeout for the initial connection setup (similar to hopen (`host:port;<timeout)) if timeout is not set
      - `encoding` (`string`) - string encoding for data deserialization
      - `reader_class` (subclass of `QReader`) - data deserializer
      - `writer_class` (subclass of `QWriter`) - data serializer
@@ -90,7 +90,7 @@ class QConnection(object):
         self._protocol_version = None
 
         self.timeout = timeout
-        self.connectionTimeout = connectionTimeout
+        self.connectionTimeout = connectionTimeout if timeout is None else timeout
 
         self._encoding = encoding
 


### PR DESCRIPTION
This pull request adds a connectionTimeout argument to qpython.QConnection. As the name suggests, it specifies a timeout for the initial connection setup. It is designed to mimic the behavior of the timeout argument that q's hopen has, i.e. it defines a maximum wait time for initiating a connection (socket and initial handshake) with a remote q process.

The behavior of the existing timeout parameter is different as it applies to _all_ IO operations over the connection, i.e. the initial connection setup and subsequent queries. In other words, besides limiting the connection setup time, it also limits the maximum duration of queries submitted via qPython to the timeout value. As is, qPtyhon does not offer the ability to change the timeout once it is in place even though the underlying implementation (socket.settimeout()) supports this.

Clients that want to time-box only the connection setup (for example because there are multiple q instances offering the same service, but some of them may be busy servicing other clients) have to accept that the timeout also carries forward to all queries submitted over the connection. Due to the details of the underlying implementation it is not possible to work around the issue by simply ignoring the exception that is thrown should the timeout hit.

The patch enables clients to apply a timeout only to the connection setup phase. It takes care not to change the scope of the existing timeout parameter, that is if both are specified, the timeout parameter takes precedence.

In general, I would question the utility of the original implementation, i.e. mapping the timeout argument to QConnection to socket.settimeout(), for the reason stated above. From my perspective it would be more consistent to follow q's behavior and have a connection setup timeout, but no outgoing query timeout.