### PR TITLE
allow new capacity byte for connection handshake

### DIFF
--- a/qpython/fastutils.pyx
+++ b/qpython/fastutils.pyx
@@ -17,8 +17,8 @@
 import numpy
 cimport numpy
 
-DTYPE = numpy.int
-ctypedef numpy.int_t DTYPE_t
+DTYPE = numpy.uint
+ctypedef numpy.uint_t DTYPE_t
 DTYPE8 = numpy.int
 ctypedef numpy.uint8_t DTYPE8_t
 

--- a/qpython/qconnection.py
+++ b/qpython/qconnection.py
@@ -65,6 +65,8 @@ class QConnection(object):
      - `encoding` (`string`) - string encoding for data deserialization
      - `reader_class` (subclass of `QReader`) - data deserializer
      - `writer_class` (subclass of `QWriter`) - data serializer
+     - `capacity_byte` (byte) - handshake capacity byte. Use it only if you
+        want to override the default. See https://code.kx.com/v2/basics/ipc/#handshake
     :Options: 
      - `raw` (`boolean`) - if ``True`` returns raw data chunk instead of parsed 
        data, **Default**: ``False``
@@ -78,11 +80,12 @@ class QConnection(object):
     '''
 
 
-    def __init__(self, host, port, username = None, password = None, timeout = None, encoding = 'latin-1', reader_class = None, writer_class = None, **options):
+    def __init__(self, host, port, username = None, password = None, timeout = None, encoding = 'latin-1', reader_class = None, writer_class = None, capacity_byte = b'\3', **options):
         self.host = host
         self.port = port
         self.username = username
         self.password = password
+        self.capacity_byte = capacity_byte
 
         self._connection = None
         self._connection_file = None
@@ -186,7 +189,7 @@ class QConnection(object):
         '''Performs a IPC protocol handshake.'''
         credentials = (self.username if self.username else '') + ':' + (self.password if self.password else '')
         credentials = credentials.encode(self._encoding)
-        self._connection.send(credentials + b'\3\0')
+        self._connection.send(credentials + self.capacity_byte + b'\0')
         response = self._connection.recv(1)
 
         if len(response) != 1:

--- a/qpython/utils.py
+++ b/qpython/utils.py
@@ -18,19 +18,19 @@ import numpy
 
 
 def uncompress(data, uncompressed_size):
-    _0 = numpy.intc(0)
-    _1 = numpy.intc(1)
-    _2 = numpy.intc(2)
-    _128 = numpy.intc(128)
-    _255 = numpy.intc(255)
+    _0 = numpy.uintc(0)
+    _1 = numpy.uintc(1)
+    _2 = numpy.uintc(2)
+    _128 = numpy.uintc(128)
+    _255 = numpy.uintc(255)
 
     n, r, s, p = _0, _0, _0, _0
     i, d = _1, _1
     f = _255 & data[_0]
 
-    ptrs = numpy.zeros(256, dtype = numpy.intc)
+    ptrs = numpy.zeros(256, dtype = numpy.uintc)
     uncompressed = numpy.zeros(uncompressed_size, dtype = numpy.uint8)
-    idx = numpy.arange(uncompressed_size, dtype = numpy.intc)
+    idx = numpy.arange(uncompressed_size, dtype = numpy.uintc)
 
     while s < uncompressed_size:
         pp = p + _1


### PR DESCRIPTION
Recent Kdb versions support new capacity bytes for connection handshake. See https://code.kx.com/v2/basics/ipc/#handshake The change is to make it possible to override the default to support large memory > 2GB.