### PR TITLE
fixing issue for pandas version greater than 1.3.5

### DIFF
--- a/qpython/_pandas.py
+++ b/qpython/_pandas.py
@@ -111,9 +111,12 @@ class PandasQReader(QReader):
         qlist = QReader._read_list(self, qtype = qtype)
 
         if self._options.pandas:
-            if -abs(qtype) not in [QMONTH, QDATE, QDATETIME, QMINUTE, QSECOND, QTIME, QTIMESTAMP, QTIMESPAN, QSYMBOL]:
+            if -abs(qtype) not in [QMONTH, QDATE, QDATETIME, QMINUTE, QSECOND, QTIME, QTIMESTAMP, QTIMESPAN, QSYMBOL, QBOOL]:
                 null = QNULLMAP[-abs(qtype)][1]
-                ps = pandas.Series(data = qlist).replace(null, numpy.NaN)
+                ps = pandas.Series(data=qlist)
+                mask_array = numpy.array(ps) == null
+                if len(ps[mask_array]) > 0:
+                    ps[mask_array] = numpy.nan
             else:
                 ps = pandas.Series(data = qlist)
 
@@ -121,6 +124,7 @@ class PandasQReader(QReader):
             return ps
         else:
             return qlist
+
 
 
     @parse(QGENERAL_LIST)


### PR DESCRIPTION
There was a bug when loading data in dataframe for version of panda greater than 1.3.5.
This was due to the replace function used to replace null value of q by np.nan.
I fixed it and ensured that all tests in pandas_test.py are passing now.